### PR TITLE
Allow an evaluate to handle an array of parses

### DIFF
--- a/ts/src/walker.ts
+++ b/ts/src/walker.ts
@@ -13,7 +13,11 @@ export function walkFrom(resource: model.ResourceParse, from: traversal.Traversa
     evaluateFrom(resource, from, evalise(walker));
 }
 
-export function evaluate<T>(resource: model.ResourceParse, evaluator: ResourceEvaluator<T>): T[] {
+export function evaluate<T>(resource: model.ResourceParse | model.ResourceParse[], evaluator: ResourceEvaluator<T>): T[] {
+    if (Array.isArray(resource)) {
+        const results = resource.map((r) => evaluate(r, evaluator));
+        return Array.of<T>().concat(...results);
+    }
     return evaluateImpl({ valueType: 'map', entries: resource.entries }, [], evaluator);
 }
 

--- a/ts/test/walker.ts
+++ b/ts/test/walker.ts
@@ -46,8 +46,26 @@ status:
   good: verygood
 `;
 
+const multiText = `---
+apiVersion: apps/v1
+metadata:
+  labels:
+    wizz: bang
+containers:
+  - cont1
+  - 123
+---
+apiVersion: extensions/v2
+metadata:
+  wizz:
+    foo: fooval
+containers:
+  - cont2
+`;
+
 const simple = parser.parseYAML(simpleText)[0];
 const test = parser.parseYAML(testText)[0];
+const multi = parser.parseYAML(multiText);
 
 describe('AST walker', () => {
     it('should notify on every node', () => {
@@ -198,6 +216,16 @@ describe('AST evaluator', () => {
         };
         const results = parser.evaluate(simple, evaluator);
         assert.equal(results.length, 3);
+    });
+
+    it('can evaluate across multiple manifests', () => {
+        const evaluator = {
+            onString: function*(_v: parser.StringValue, _a: ReadonlyArray<parser.Ancestor>) {
+                yield 1;
+            }
+        };
+        const results = parser.evaluate(multi, evaluator);
+        assert.equal(results.length, 6);
     });
 
     it('should be able to walk from a particular node', () => {


### PR DESCRIPTION
Because `parseYAML` etc has to return an array, and this saves users reconcatting all the results themselves (particularly aggravating when there's usually only one!).