### PR TITLE
Highlighting range for traversal

### DIFF
--- a/ts/src/convenience.ts
+++ b/ts/src/convenience.ts
@@ -45,7 +45,7 @@ export interface ScalarTraversalEntry<T> extends TraversalEntry {
 }
 
 export function asTraversable(impl: model.ResourceParse): MapTraversalEntry {
-    return traversalEntryOfMap({ valueType: 'map', entries: impl.entries });
+    return traversalEntryOfMap({ valueType: 'map', entries: impl.entries, range: impl.range });
 }
 
 function withChildAccessors(n: TraversalEntry): any {

--- a/ts/src/helm.ts
+++ b/ts/src/helm.ts
@@ -28,7 +28,7 @@ function encodeWithTemplateMarkers(s: string): string {
 }
 
 function unmutilate(parse: model.ResourceParse, originalText: string): model.ResourceParse {
-    return unmutilateMap({ valueType: 'map', entries: parse.entries }, originalText);
+    return unmutilateMap({ valueType: 'map', entries: parse.entries, range: parse.range }, originalText);
 }
 
 function unmutilateNode(node: model.Value, originalText: string): model.Value {
@@ -57,7 +57,7 @@ function unmutilateString(s: model.StringValue, originalText: string): model.Str
 }
 
 function unmutilateArray(array: model.ArrayValue, originalText: string): model.ArrayValue {
-    return { valueType: 'array', items: array.items.map((v) => unmutilateNode(v, originalText)) };
+    return { valueType: 'array', items: array.items.map((v) => unmutilateNode(v, originalText)), range: array.range };
 }
 
 function unmutilateMap(map: model.MapValue, originalText: string): model.MapValue {
@@ -65,7 +65,7 @@ function unmutilateMap(map: model.MapValue, originalText: string): model.MapValu
     for (const [key, value] of Object.entries(map.entries)) {
         entries[key] = unmutilateResourceMapEntry(value, originalText);
     }
-    return { valueType: 'map', entries: entries };
+    return { valueType: 'map', entries: entries, range: map.range };
 }
 
 function unmutilateResourceMapEntry(entry: model.ResourceMapEntry, originalText: string): model.ResourceMapEntry {

--- a/ts/src/helm.ts
+++ b/ts/src/helm.ts
@@ -69,5 +69,5 @@ function unmutilateMap(map: model.MapValue, originalText: string): model.MapValu
 }
 
 function unmutilateResourceMapEntry(entry: model.ResourceMapEntry, originalText: string): model.ResourceMapEntry {
-    return { keyRange: entry.keyRange, value: unmutilateNode(entry.value, originalText) };
+    return { key: entry.key, keyRange: entry.keyRange, range: entry.range, value: unmutilateNode(entry.value, originalText) };
 }

--- a/ts/src/json.ts
+++ b/ts/src/json.ts
@@ -7,7 +7,7 @@ export function parseJSON(text: string): model.ResourceParse[] {
 }
 
 function dequote(source: model.ResourceParse): model.ResourceParse {
-    return { entries: dequoteKeys(source.entries) };
+    return { entries: dequoteKeys(source.entries), range: source.range };
 }
 
 function dequoteKeys(source: { [key: string ]: model.ResourceMapEntry }): { [key: string ]: model.ResourceMapEntry } {
@@ -31,9 +31,9 @@ function dequoteValue(v: model.Value): model.Value {
         case 'missing':
             return v;
         case 'array':
-            return { valueType: 'array', items: v.items.map(dequoteValue) };
+            return { valueType: 'array', items: v.items.map(dequoteValue), range: v.range };
         case 'map':
-            return { valueType: 'map', entries: dequoteKeys(v.entries) };
+            return { valueType: 'map', entries: dequoteKeys(v.entries), range: v.range };
     }
 }
 

--- a/ts/src/json.ts
+++ b/ts/src/json.ts
@@ -20,7 +20,7 @@ function dequoteKeys(source: { [key: string ]: model.ResourceMapEntry }): { [key
 }
 
 function dequoteMapEntry(source: model.ResourceMapEntry): model.ResourceMapEntry {
-    return { keyRange: source.keyRange, value: dequoteValue(source.value) };
+    return { key: source.key, keyRange: source.keyRange, range: source.range, value: dequoteValue(source.value) };
 }
 
 function dequoteValue(v: model.Value): model.Value {

--- a/ts/src/model.ts
+++ b/ts/src/model.ts
@@ -5,6 +5,7 @@ export interface Range {
 
 export interface ResourceParse {
     readonly entries: { [key: string]: ResourceMapEntry };
+    readonly range: Range;
 }
 
 export interface ResourceMapEntry {
@@ -36,11 +37,13 @@ export interface BooleanValue {
 export interface ArrayValue {
     readonly valueType: 'array';
     readonly items: ReadonlyArray<Value>;
+    readonly range: Range;
 }
 
 export interface MapValue {
     readonly valueType: 'map';
     readonly entries: { [key: string]: ResourceMapEntry };
+    readonly range: Range;
 }
 
 // E.g. the case where there is a header with no value
@@ -50,6 +53,7 @@ export interface MapValue {
 // In the above, 'naughty' will have a MissingValue
 export interface MissingValue {
     readonly valueType: 'missing';
+    readonly range: Range;  // TODO: would rather not but it makes life easier
 }
 
 export type Value =

--- a/ts/src/model.ts
+++ b/ts/src/model.ts
@@ -9,7 +9,9 @@ export interface ResourceParse {
 }
 
 export interface ResourceMapEntry {
+    readonly key: string;
     readonly keyRange: Range;  // TODO: or have the parse be an array of [Ranged<string>, Value]
+    readonly range: Range;
     readonly value: Value;
 }
 

--- a/ts/src/walker.ts
+++ b/ts/src/walker.ts
@@ -18,7 +18,7 @@ export function evaluate<T>(resource: model.ResourceParse | model.ResourceParse[
         const results = resource.map((r) => evaluate(r, evaluator));
         return Array.of<T>().concat(...results);
     }
-    return evaluateImpl({ valueType: 'map', entries: resource.entries }, [], evaluator);
+    return evaluateImpl({ valueType: 'map', entries: resource.entries, range: resource.range }, [], evaluator);
 }
 
 export function evaluateFromValue<T>(resource: model.ResourceParse, from: model.Value, evaluator: ResourceEvaluator<T>): T[] {

--- a/ts/src/yaml.ts
+++ b/ts/src/yaml.ts
@@ -35,8 +35,10 @@ function parseMappingsInto(mappings: yp.YAMLMapping[], mapParse: { [key: string]
     for (const m of mappings) {
         const value = parseNode(m.value);
         mapParse[m.key.rawValue] = {
+            key: m.key.value,
             keyRange: { start: m.key.startPosition, end: m.key.endPosition },
-            value: value
+            value: value,
+            range: { start: m.startPosition, end: m.endPosition },
         };
     }
 }

--- a/ts/test/convenience.ts
+++ b/ts/test/convenience.ts
@@ -118,6 +118,37 @@ describe('mostly-type-safe convenience layer', () => {
         assert.equal(arrayAsNumbers[2].valid(), true);
         assert.equal(arrayAsNumbers[2].value(), 1234);
     });
+
+    // const rangeTextText = 'str1: s1\nmap1:\n  map11:\n    foo: 123\n    bar: 456\nmap2:\n  baz: 789\narr:\n- a\n- b\n- m:\n    am1: 987';
+
+    // it('can give out a containing range for nonexistent nodes', () => {
+    //     const resource = parser.parseYAML(rangeTextText)[0];
+    //     const result = parser.asTraversable(resource);
+
+    //     function assertNearestRangeIs(entry: parser.TraversalEntry, start: number, end: number) {
+    //         assert.equal(parser.nearestUsableRange(entry)?.start, start);
+    //         assert.equal(parser.nearestUsableRange(entry)?.end, end);
+    //     }
+
+    //     const existentTopLevel = result.child('str1');
+    //     assertNearestRangeIs(existentTopLevel, 0, 4);
+
+    //     const nonExistentTopLevel = result.child('wibble');
+    //     assert.equal(parser.nearestUsableRange(nonExistentTopLevel), undefined);
+
+    //     const belowNonExistentTopLevel = result.map('wibble').child('wobble');
+    //     assert.equal(parser.nearestUsableRange(belowNonExistentTopLevel), undefined);
+
+    //     assertNearestRangeIs(result.map('map1').map('nope'), 9, 13);
+    //     assertNearestRangeIs(result.map('map1').map('nope').string('nope2'), 9, 13);
+    //     assertNearestRangeIs(result.map('map1').map('map11'), 17, 22);
+    //     assertNearestRangeIs(result.map('map1').map('map11').string('nope2'), 17, 22);
+
+    //     assertNearestRangeIs(result.array('arr').string(0), 74, 75);
+    //     assertNearestRangeIs(result.array('arr').number(0), 74, 75);
+    //     assertNearestRangeIs(result.array('arr').map(0).child('nope'), 74, 75);
+    //     assertNearestRangeIs(result.array('arr').map(2).child('nope'), 82, 83);
+    // });
 });
 
 describe('the typed-but-only-weakly convenience layer', () => {

--- a/ts/test/convenience.ts
+++ b/ts/test/convenience.ts
@@ -119,36 +119,32 @@ describe('mostly-type-safe convenience layer', () => {
         assert.equal(arrayAsNumbers[2].value(), 1234);
     });
 
-    // const rangeTextText = 'str1: s1\nmap1:\n  map11:\n    foo: 123\n    bar: 456\nmap2:\n  baz: 789\narr:\n- a\n- b\n- m:\n    am1: 987';
+    const rangeTextText = 'str1: s1\nmap1:\n  map11:\n    foo: 123\n    bar: 456\nmap2:\n  baz: 789\narr:\n- a\n- b\n- m:\n    am1: 987';
 
-    // it('can give out a containing range for nonexistent nodes', () => {
-    //     const resource = parser.parseYAML(rangeTextText)[0];
-    //     const result = parser.asTraversable(resource);
+    it('can give out a highlight range for nonexistent nodes', () => {
+        const resource = parser.parseYAML(rangeTextText)[0];
+        const result = parser.asTraversable(resource);
 
-    //     function assertNearestRangeIs(entry: parser.TraversalEntry, start: number, end: number) {
-    //         assert.equal(parser.nearestUsableRange(entry)?.start, start);
-    //         assert.equal(parser.nearestUsableRange(entry)?.end, end);
-    //     }
+        function assertHighlightRangeIs(entry: parser.TraversalEntry, start: number, end: number) {
+            assert.equal(parser.highlightRange(entry)?.start, start);
+            assert.equal(parser.highlightRange(entry)?.end, end);
+        }
 
-    //     const existentTopLevel = result.child('str1');
-    //     assertNearestRangeIs(existentTopLevel, 0, 4);
+        assertHighlightRangeIs(result.child('str1'), 6, 8);  // because this is the value range not the key range
 
-    //     const nonExistentTopLevel = result.child('wibble');
-    //     assert.equal(parser.nearestUsableRange(nonExistentTopLevel), undefined);
+        assertHighlightRangeIs(result.child('wibble'), 0, 97);  // TODO: maybe the default should be the first entry in the file or something
+        assertHighlightRangeIs(result.map('wibble').child('wobble'), 0, 97);
 
-    //     const belowNonExistentTopLevel = result.map('wibble').child('wobble');
-    //     assert.equal(parser.nearestUsableRange(belowNonExistentTopLevel), undefined);
+        assertHighlightRangeIs(result.map('map1').map('nope'), 9, 13);
+        assertHighlightRangeIs(result.map('map1').map('nope').string('nope2'), 9, 13);
+        assertHighlightRangeIs(result.map('map1').map('map11'), 28, 49);  // TODO: I feel this is inconsistent - nonexistent children of this would report the key range not the node itself
+        assertHighlightRangeIs(result.map('map1').map('map11').string('nope2'), 17, 22);
 
-    //     assertNearestRangeIs(result.map('map1').map('nope'), 9, 13);
-    //     assertNearestRangeIs(result.map('map1').map('nope').string('nope2'), 9, 13);
-    //     assertNearestRangeIs(result.map('map1').map('map11'), 17, 22);
-    //     assertNearestRangeIs(result.map('map1').map('map11').string('nope2'), 17, 22);
-
-    //     assertNearestRangeIs(result.array('arr').string(0), 74, 75);
-    //     assertNearestRangeIs(result.array('arr').number(0), 74, 75);
-    //     assertNearestRangeIs(result.array('arr').map(0).child('nope'), 74, 75);
-    //     assertNearestRangeIs(result.array('arr').map(2).child('nope'), 82, 83);
-    // });
+        assertHighlightRangeIs(result.array('arr').string(0), 74, 75);
+        assertHighlightRangeIs(result.array('arr').number(0), 74, 75);
+        assertHighlightRangeIs(result.array('arr').map(0).child('nope'), 74, 75);
+        assertHighlightRangeIs(result.array('arr').map(2).child('nope'), 72, 98);  // TODO: again feels like 'nonexistent child of existent map' is blowing up the wrong thing - this is the whole array  // TODO: why 98 rather than 97?!
+    });
 });
 
 describe('the typed-but-only-weakly convenience layer', () => {


### PR DESCRIPTION
When you do a traversal you can end up at a nonexistent node and not know how many of its ancestors ago you went off the map.  This means you don't know which point to get the range from to do any error highlighting.  E.g.

```
const containers = pod.speccontainers;
if (containers.valid()) {
  for (const memLimit of containers.maps().map((c) => c.resources.limits.memory)) {
    if (!memLimit.exists() || !memLimit.valid()) {
      // uh oh... want to warn, but can't easily refer to any range below c
    }
  }
}
```

And you can't walk the tree looking for an ancestor because **drum roll** the node doesn't exist!

This PR tracks the nearest existing ancestor of a traversal entry, and provides a `highlightRange` function which returns the range of that ancestor.  The ranges are a bit inconsistent as to whether it highlights the key, the body or the entire thing, but it will do as a first stab - the initial goal is to have something that will at least point the user at the right place, even if not quite as precisely as would be nice!